### PR TITLE
Add syntax highlight to code example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ notifications of received events.  With those packages together, we can write
 elegant tests like the following.
 
 
-```
+```go
 type Harness struct {
 	RouteLogger *webhook.RouteLogger
 }


### PR DESCRIPTION
It's better to read code examples with syntax highlight.