### PR TITLE
Allow up to 1 MB requests

### DIFF
--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -25,7 +25,7 @@ func New(c Config, opts ...func(*Webhook)) *Webhook {
 }
 
 func (h *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rdr := http.MaxBytesReader(w, r.Body, 30000)
+	rdr := http.MaxBytesReader(w, r.Body, 1024*1024)
 	defer rdr.Close()
 
 	bs, err := ioutil.ReadAll(rdr)


### PR DESCRIPTION
I'm adding an mme-e2e test for batch requests which are larger than 30 KB.

Testing not required because this is only used by mme-e2e.
